### PR TITLE
[FIX] #147 - fix like sort - change string to int

### DIFF
--- a/functions/api/routes/classroomPost/classroomPostMajorListGET.js
+++ b/functions/api/routes/classroomPost/classroomPostMajorListGET.js
@@ -69,7 +69,9 @@ module.exports = async (req, res) => {
     if (sort === "recent") {
       classroomPostList = _.sortBy(classroomPostList, "createdAt").reverse();
     } else if (sort === "like") {
-      classroomPostList = _.sortBy(classroomPostList, "likeCount").reverse();
+      classroomPostList = _.sortBy(classroomPostList, (obj) =>
+        parseInt(obj.likeCount, 10),
+      ).reverse();
     } else {
       return res
         .status(statusCode.BAD_REQUEST)

--- a/functions/api/routes/reviewPost/reviewPostListPOST.js
+++ b/functions/api/routes/reviewPost/reviewPostListPOST.js
@@ -87,7 +87,7 @@ module.exports = async (req, res) => {
     if (sort === "recent") {
       reviewPostList = _.sortBy(reviewPostList, "createdAt").reverse();
     } else if (sort === "like") {
-      reviewPostList = _.sortBy(reviewPostList, "likeCount").reverse();
+      reviewPostList = _.sortBy(reviewPostList, (obj) => parseInt(obj.likeCount, 10)).reverse();
     } else {
       return res
         .status(statusCode.BAD_REQUEST)

--- a/functions/api/routes/user/userMypageClassroomPostListGET.js
+++ b/functions/api/routes/user/userMypageClassroomPostListGET.js
@@ -65,7 +65,9 @@ module.exports = async (req, res) => {
     if (sort === "recent") {
       classroomPostList = _.sortBy(classroomPostList, "createdAt").reverse();
     } else if (sort === "like") {
-      classroomPostList = _.sortBy(classroomPostList, "likeCount").reverse();
+      classroomPostList = _.sortBy(classroomPostList, (obj) =>
+        parseInt(obj.likeCount, 10),
+      ).reverse();
     } else {
       return res
         .status(statusCode.BAD_REQUEST)


### PR DESCRIPTION
* closed #147 

sort filter로 리스트 get하는 코드에서 likecount를 string으로 가져와서 3 보다 12가 작다고 잘못 정렬하는 오류를 해결하였습니다.
parseInt를 사용해서 제대로 정렬 구현했습니다.

!!!! 나중에 리팩토링할 때 likeCount를 int로 바꿔서 가져온다면 다시 원래 코드로 변경해도 괜찮습니다.