### PR TITLE
[FEAT] #211 - authLogoutPOST

### DIFF
--- a/functions/api/routes/auth/authLogoutPOST.js
+++ b/functions/api/routes/auth/authLogoutPOST.js
@@ -1,0 +1,49 @@
+const functions = require("firebase-functions");
+const db = require("../../../db/db");
+const util = require("../../../lib/util");
+const statusCode = require("../../../constants/statusCode");
+const responseMessage = require("../../../constants/responseMessage");
+const { userDB } = require("../../../db");
+const slackAPI = require("../../../middlewares/slackAPI");
+
+module.exports = async (req, res) => {
+  let client;
+  try {
+    client = await db.connect(req);
+
+    // 리프레쉬토큰 업데이트
+    let refreshTokenUpdated = await userDB.updateUserByLogout(client, req.user.id);
+    if (!refreshTokenUpdated) {
+      return res
+        .status(statusCode.BAD_REQUEST)
+        .send(util.fail(statusCode.BAD_REQUEST, responseMessage.UPDATE_REFRESH_TOKEN_FAIL));
+    }
+
+    refreshTokenUpdated = {
+      userId: refreshTokenUpdated.id,
+      refreshToken: refreshTokenUpdated.refreshToken,
+      updatedAt: refreshTokenUpdated.updatedAt,
+    };
+
+    res
+      .status(statusCode.OK)
+      .send(util.success(statusCode.OK, responseMessage.LOGOUT_SUCCESS, { refreshTokenUpdated }));
+  } catch (error) {
+    functions.logger.error(
+      `[ERROR] [${req.method.toUpperCase()}] ${req.originalUrl}`,
+      `[CONTENT] ${error}`,
+    );
+    console.log(error);
+
+    const slackMessage = `[ERROR] [${req.method.toUpperCase()}] ${
+      req.originalUrl
+    } ${error} ${JSON.stringify(error)}`;
+    slackAPI.sendMessageToSlack(slackMessage, slackAPI.DEV_WEB_HOOK_ERROR_MONITORING);
+
+    res
+      .status(statusCode.INTERNAL_SERVER_ERROR)
+      .send(util.fail(statusCode.INTERNAL_SERVER_ERROR, responseMessage.INTERNAL_SERVER_ERROR));
+  } finally {
+    client.release();
+  }
+};

--- a/functions/api/routes/auth/authLogoutPOST.js
+++ b/functions/api/routes/auth/authLogoutPOST.js
@@ -15,8 +15,10 @@ module.exports = async (req, res) => {
     const refreshTokenUpdated = await userDB.updateUserByLogout(client, req.user.id);
     if (!refreshTokenUpdated) {
       return res
-        .status(statusCode.BAD_REQUEST)
-        .send(util.fail(statusCode.BAD_REQUEST, responseMessage.UPDATE_REFRESH_TOKEN_FAIL));
+        .status(statusCode.INTERNAL_SERVER_ERROR)
+        .send(
+          util.fail(statusCode.INTERNAL_SERVER_ERROR, responseMessage.UPDATE_REFRESH_TOKEN_FAIL),
+        );
     }
 
     res.status(statusCode.OK).send(util.success(statusCode.OK, responseMessage.LOGOUT_SUCCESS));

--- a/functions/api/routes/auth/authLogoutPOST.js
+++ b/functions/api/routes/auth/authLogoutPOST.js
@@ -11,7 +11,7 @@ module.exports = async (req, res) => {
   try {
     client = await db.connect(req);
 
-    // 리프레쉬토큰 업데이트
+    // 리프레시 토큰 업데이트
     const refreshTokenUpdated = await userDB.updateUserByLogout(client, req.user.id);
     if (!refreshTokenUpdated) {
       return res

--- a/functions/api/routes/auth/authLogoutPOST.js
+++ b/functions/api/routes/auth/authLogoutPOST.js
@@ -12,22 +12,14 @@ module.exports = async (req, res) => {
     client = await db.connect(req);
 
     // 리프레쉬토큰 업데이트
-    let refreshTokenUpdated = await userDB.updateUserByLogout(client, req.user.id);
+    const refreshTokenUpdated = await userDB.updateUserByLogout(client, req.user.id);
     if (!refreshTokenUpdated) {
       return res
         .status(statusCode.BAD_REQUEST)
         .send(util.fail(statusCode.BAD_REQUEST, responseMessage.UPDATE_REFRESH_TOKEN_FAIL));
     }
 
-    refreshTokenUpdated = {
-      userId: refreshTokenUpdated.id,
-      refreshToken: refreshTokenUpdated.refreshToken,
-      updatedAt: refreshTokenUpdated.updatedAt,
-    };
-
-    res
-      .status(statusCode.OK)
-      .send(util.success(statusCode.OK, responseMessage.LOGOUT_SUCCESS, { refreshTokenUpdated }));
+    res.status(statusCode.OK).send(util.success(statusCode.OK, responseMessage.LOGOUT_SUCCESS));
   } catch (error) {
     functions.logger.error(
       `[ERROR] [${req.method.toUpperCase()}] ${req.originalUrl}`,

--- a/functions/api/routes/auth/index.js
+++ b/functions/api/routes/auth/index.js
@@ -6,6 +6,7 @@ router.post("/duplication-check/nickname", require("./authDuplicationCheckNickna
 router.post("/duplication-check/email", require("./authDuplicationCheckEmailPOST"));
 router.post("/signup", require("./authSignupPOST"));
 router.post("/login", require("./authLoginPOST"));
+router.post("/logout", checkUser, require("./authLogoutPOST"));
 router.post("/renewal/token", require("./authRenewalTokenPOST"));
 router.post("/reset/password", require("./authResetPasswordPOST"));
 router.get("/university/:universityId", require("./authUniversityGET"));

--- a/functions/constants/responseMessage.js
+++ b/functions/constants/responseMessage.js
@@ -61,7 +61,7 @@ module.exports = {
   TOKEN_INVALID: "토큰이 유효하지 않습니다.",
   TOKEN_EMPTY: "토큰이 없습니다.",
   UPDATE_DEVICE_TOKEN_FAIL: "디바이스 토큰 업데이트 실패",
-  UPDATE_REFRESH_TOKEN_FAIL: "리프레스 토큰 업데이트 실패",
+  UPDATE_REFRESH_TOKEN_FAIL: "리프레시 토큰 업데이트 실패",
   UPDATE_TOKEN_SUCCESS: "토큰 재발급 성공",
   ALREADY_UPDATED_TOKEN_SUCCESS: "둘 다 유효한 토큰입니다.",
 

--- a/functions/constants/responseMessage.js
+++ b/functions/constants/responseMessage.js
@@ -19,6 +19,9 @@ module.exports = {
   MISS_MATCH_PW: "비밀번호가 맞지 않습니다.",
   INVALID_EMAIL: "이메일 형식을 확인해주세요.",
 
+  // 로그아웃
+  LOGOUT_SUCCESS: "로그아웃 성공",
+
   // 프로필 조회
   READ_PROFILE_SUCCESS: "프로필 조회 성공",
 

--- a/functions/db/user.js
+++ b/functions/db/user.js
@@ -258,6 +258,20 @@ const getUserByRefreshToken = async (client, refreshtoken) => {
   return convertSnakeToCamel.keysToCamel(rows[0]);
 };
 
+const updateUserByLogout = async (client, userId) => {
+  const { rows } = await client.query(
+    `
+    UPDATE "user"
+    SET refresh_token = null, updated_at = now()
+    WHERE id = $1
+    AND is_deleted = FALSE
+    RETURNING *
+    `,
+    [userId],
+  );
+  return convertSnakeToCamel.keysToCamel(rows[0]);
+};
+
 module.exports = {
   createUser,
   getUserByNickname,
@@ -272,4 +286,5 @@ module.exports = {
   getUserListByCommentPostId,
   updateUserByMypage,
   getUserByRefreshToken,
+  updateUserByLogout,
 };


### PR DESCRIPTION
- closed #211 

- 유저 db에서 로그아웃한 유저의 refresh_token 컬럼 값을 null로 변경
-> 현재 플로우에서는 로그아웃 후에 무조건 재로그인 -> 새로운 refreshtoken 생성하기 때문에 null로 넣어도 상관없음


