### PR TITLE
[FEAT] 신고 리펙토링(dateHandlers 생성 및 dayjs 사용), 신고 알럿 변경사항 반영

### DIFF
--- a/functions/api/routes/auth/authLoginPOST.js
+++ b/functions/api/routes/auth/authLoginPOST.js
@@ -118,7 +118,7 @@ module.exports = async (req, res) => {
       const expirationDate = dateHandlers.getExpirationDateByMonth(reportCreatedDate, reportPeriod);
 
       // 신고 만료 날짜 지났으면
-      if (expirationDate < today) {
+      if (expirationDate.format("YYYY.MM.DD HH:mm:ss") < today.format("YYYY.MM.DD HH:mm:ss")) {
         // 신고 테이블에서 유저에게 온 접수된 신고들을 만료시킴
         const deletedReportList = await reportDB.deleteReportList(client, userData.id);
 

--- a/functions/api/routes/classroomPost/classroomPostInformationGET.js
+++ b/functions/api/routes/classroomPost/classroomPostInformationGET.js
@@ -6,6 +6,8 @@ const postType = require("../../../constants/postType");
 const db = require("../../../db/db");
 const { classroomPostDB, userDB, majorDB, likeDB, commentDB } = require("../../../db");
 const slackAPI = require("../../../middlewares/slackAPI");
+const dateHandlers = require("../../../lib/dateHandlers");
+const reportPeriodType = require("../../../constants/reportPeriodType");
 
 module.exports = async (req, res) => {
   const { postId } = req.params;
@@ -14,18 +16,44 @@ module.exports = async (req, res) => {
       .status(statusCode.BAD_REQUEST)
       .send(util.fail(statusCode.BAD_REQUEST, responseMessage.NULL_VALUE));
 
+  // 신고당한 유저
+  if (req.user.reportCreatedAt) {
+    // 유저 신고 기간
+    let reportPeriod;
+
+    // 알럿 메세지
+    let reportResponseMessage;
+
+    if (req.user.reportCount === 1) {
+      reportPeriod = reportPeriodType.FIRST_PERIOD;
+    } else if (req.user.reportCount === 2) {
+      reportPeriod = reportPeriodType.SECOND_PERIOD;
+    } else if (req.user.reportCount === 3) {
+      reportPeriod = reportPeriodType.THIRD_PERIOD;
+    } else if (req.user.reportCount >= 4) {
+      reportResponseMessage = `신고 누적이용자로 앞으로 글 열람 및 글 작성이 불가능합니다.`;
+    }
+
+    // 신고 만료 날짜
+    const expirationDate = dateHandlers.getExpirationDateByMonth(
+      req.user.reportCreatedAt,
+      reportPeriod,
+    );
+
+    reportResponseMessage = `신고 누적이용자로 ${expirationDate.format(
+      "YY년 MM월 DD일",
+    )}까지 글 열람 및 글 작성이 불가능합니다.`;
+
+    return res
+      .status(statusCode.FORBIDDEN)
+      .send(util.fail(statusCode.FORBIDDEN, reportResponseMessage));
+  }
+
   // 후기 미작성자는 정보글 상세조회 불가
   if (req.user.isReviewed === false) {
     return res
       .status(statusCode.FORBIDDEN)
       .send(util.fail(statusCode.FORBIDDEN, responseMessage.IS_REVIEWED_FALSE));
-  }
-
-  // 신고당한 유저
-  if (req.user.reportCreatedAt) {
-    return res
-      .status(statusCode.FORBIDDEN)
-      .send(util.fail(statusCode.FORBIDDEN, responseMessage.FORBIDDEN_ACCESS_REPORT));
   }
 
   let client;

--- a/functions/api/routes/classroomPost/classroomPostInformationGET.js
+++ b/functions/api/routes/classroomPost/classroomPostInformationGET.js
@@ -31,7 +31,7 @@ module.exports = async (req, res) => {
     } else if (req.user.reportCount === 3) {
       reportPeriod = reportPeriodType.THIRD_PERIOD;
     } else if (req.user.reportCount >= 4) {
-      reportResponseMessage = `신고 누적이용자로 앞으로 글 열람 및 글 작성이 불가능합니다.`;
+      reportResponseMessage = `신고 누적으로 글 열람 및 작성이 영구적으로 제한됩니다.`;
     }
 
     // 신고 만료 날짜
@@ -41,8 +41,8 @@ module.exports = async (req, res) => {
     );
 
     reportResponseMessage = `신고 누적이용자로 ${expirationDate.format(
-      "YY년 MM월 DD일",
-    )}까지 글 열람 및 글 작성이 불가능합니다.`;
+      "YYYY년 MM월 DD일",
+    )}까지 글 열람 및 작성이 불가능합니다.`;
 
     return res
       .status(statusCode.FORBIDDEN)

--- a/functions/api/routes/classroomPost/classroomPostPOST.js
+++ b/functions/api/routes/classroomPost/classroomPostPOST.js
@@ -8,6 +8,8 @@ const notificationType = require("../../../constants/notificationType");
 const postType = require("../../../constants/postType");
 const slackAPI = require("../../../middlewares/slackAPI");
 const pushAlarmHandlers = require("../../../lib/pushAlarmHandlers");
+const dateHandlers = require("../../../lib/dateHandlers");
+const reportPeriodType = require("../../../constants/reportPeriodType");
 
 module.exports = async (req, res) => {
   const { majorId, answererId, postTypeId, title, content } = req.body;
@@ -27,18 +29,44 @@ module.exports = async (req, res) => {
     }
   }
 
+  // 신고당한 유저
+  if (req.user.reportCreatedAt) {
+    // 유저 신고 기간
+    let reportPeriod;
+
+    // 알럿 메세지
+    let reportResponseMessage;
+
+    if (req.user.reportCount === 1) {
+      reportPeriod = reportPeriodType.FIRST_PERIOD;
+    } else if (req.user.reportCount === 2) {
+      reportPeriod = reportPeriodType.SECOND_PERIOD;
+    } else if (req.user.reportCount === 3) {
+      reportPeriod = reportPeriodType.THIRD_PERIOD;
+    } else if (req.user.reportCount >= 4) {
+      reportResponseMessage = `신고 누적이용자로 앞으로 글 열람 및 글 작성이 불가능합니다.`;
+    }
+
+    // 신고 만료 날짜
+    const expirationDate = dateHandlers.getExpirationDateByMonth(
+      req.user.reportCreatedAt,
+      reportPeriod,
+    );
+
+    reportResponseMessage = `신고 누적이용자로 ${expirationDate.format(
+      "YY년 MM월 DD일",
+    )}까지 글 열람 및 글 작성이 불가능합니다.`;
+
+    return res
+      .status(statusCode.FORBIDDEN)
+      .send(util.fail(statusCode.FORBIDDEN, reportResponseMessage));
+  }
+
   // 후기글 미등록 유저
   if (writer.isReviewed === false) {
     return res
       .status(statusCode.FORBIDDEN)
       .send(util.fail(statusCode.FORBIDDEN, responseMessage.IS_REVIEWED_FALSE));
-  }
-
-  // 신고당한 유저
-  if (req.user.reportCreatedAt) {
-    return res
-      .status(statusCode.FORBIDDEN)
-      .send(util.fail(statusCode.FORBIDDEN, responseMessage.FORBIDDEN_ACCESS_REPORT));
   }
 
   let client;

--- a/functions/api/routes/classroomPost/classroomPostPOST.js
+++ b/functions/api/routes/classroomPost/classroomPostPOST.js
@@ -44,7 +44,7 @@ module.exports = async (req, res) => {
     } else if (req.user.reportCount === 3) {
       reportPeriod = reportPeriodType.THIRD_PERIOD;
     } else if (req.user.reportCount >= 4) {
-      reportResponseMessage = `신고 누적이용자로 앞으로 글 열람 및 글 작성이 불가능합니다.`;
+      reportResponseMessage = `신고 누적으로 글 열람 및 작성이 영구적으로 제한됩니다.`;
     }
 
     // 신고 만료 날짜
@@ -54,8 +54,8 @@ module.exports = async (req, res) => {
     );
 
     reportResponseMessage = `신고 누적이용자로 ${expirationDate.format(
-      "YY년 MM월 DD일",
-    )}까지 글 열람 및 글 작성이 불가능합니다.`;
+      "YYYY년 MM월 DD일",
+    )}까지 글 열람 및 작성이 불가능합니다.`;
 
     return res
       .status(statusCode.FORBIDDEN)

--- a/functions/api/routes/classroomPost/classroomPostQuestionGET.js
+++ b/functions/api/routes/classroomPost/classroomPostQuestionGET.js
@@ -6,6 +6,8 @@ const postType = require("../../../constants/postType");
 const db = require("../../../db/db");
 const { classroomPostDB, userDB, majorDB, likeDB, commentDB } = require("../../../db");
 const slackAPI = require("../../../middlewares/slackAPI");
+const dateHandlers = require("../../../lib/dateHandlers");
+const reportPeriodType = require("../../../constants/reportPeriodType");
 
 module.exports = async (req, res) => {
   const { postId } = req.params;
@@ -32,17 +34,43 @@ module.exports = async (req, res) => {
 
     // 전체질문이나 1:1 질문 상세조회 불가 - 답변자가 본인인 경우 제외
     if (!(answererId && answererId === req.user.id)) {
+      // 신고당한 유저
+      if (req.user.reportCreatedAt) {
+        // 유저 신고 기간
+        let reportPeriod;
+
+        // 알럿 메세지
+        let reportResponseMessage;
+
+        if (req.user.reportCount === 1) {
+          reportPeriod = reportPeriodType.FIRST_PERIOD;
+        } else if (req.user.reportCount === 2) {
+          reportPeriod = reportPeriodType.SECOND_PERIOD;
+        } else if (req.user.reportCount === 3) {
+          reportPeriod = reportPeriodType.THIRD_PERIOD;
+        } else if (req.user.reportCount >= 4) {
+          reportResponseMessage = `신고 누적이용자로 앞으로 글 열람 및 글 작성이 불가능합니다.`;
+        }
+
+        // 신고 만료 날짜
+        const expirationDate = dateHandlers.getExpirationDateByMonth(
+          req.user.reportCreatedAt,
+          reportPeriod,
+        );
+
+        reportResponseMessage = `신고 누적이용자로 ${expirationDate.format(
+          "YY년 MM월 DD일",
+        )}까지 글 열람 및 글 작성이 불가능합니다.`;
+
+        return res
+          .status(statusCode.FORBIDDEN)
+          .send(util.fail(statusCode.FORBIDDEN, reportResponseMessage));
+      }
       // 후기 미등록 유저
       if (req.user.isReviewed === false) {
         return res
           .status(statusCode.FORBIDDEN)
           .send(util.fail(statusCode.FORBIDDEN, responseMessage.IS_REVIEWED_FALSE));
-      }
-      // 신고당한 유저
-      if (req.user.reportCreatedAt) {
-        return res
-          .status(statusCode.FORBIDDEN)
-          .send(util.fail(statusCode.FORBIDDEN, responseMessage.FORBIDDEN_ACCESS_REPORT));
       }
     }
 

--- a/functions/api/routes/classroomPost/classroomPostQuestionGET.js
+++ b/functions/api/routes/classroomPost/classroomPostQuestionGET.js
@@ -49,7 +49,7 @@ module.exports = async (req, res) => {
         } else if (req.user.reportCount === 3) {
           reportPeriod = reportPeriodType.THIRD_PERIOD;
         } else if (req.user.reportCount >= 4) {
-          reportResponseMessage = `신고 누적이용자로 앞으로 글 열람 및 글 작성이 불가능합니다.`;
+          reportResponseMessage = `신고 누적으로 글 열람 및 작성이 영구적으로 제한됩니다.`;
         }
 
         // 신고 만료 날짜
@@ -59,8 +59,8 @@ module.exports = async (req, res) => {
         );
 
         reportResponseMessage = `신고 누적이용자로 ${expirationDate.format(
-          "YY년 MM월 DD일",
-        )}까지 글 열람 및 글 작성이 불가능합니다.`;
+          "YYYY년 MM월 DD일",
+        )}까지 글 열람 및 작성이 불가능합니다.`;
 
         return res
           .status(statusCode.FORBIDDEN)

--- a/functions/api/routes/report/reportPUT.js
+++ b/functions/api/routes/report/reportPUT.js
@@ -13,7 +13,7 @@ const {
 } = require("../../../db");
 const slackAPI = require("../../../middlewares/slackAPI");
 const reportType = require("../../../constants/reportType");
-const { TOKEN_EXPIRED } = require("../../../constants/jwt");
+const dateHandlers = require("../../../lib/dateHandlers");
 
 module.exports = async (req, res) => {
   const { reportId } = req.params;
@@ -186,11 +186,8 @@ module.exports = async (req, res) => {
 
     let moreReportResponseMessage;
 
-    // 오늘 날짜를 한국 표준시로
-    const today = new Date();
-    const utcNow = today.getTime() + today.getTimezoneOffset() * 60 * 1000;
-    const KR_TIME_DIFF = 9 * 60 * 60 * 1000; // UTC보다 9시간 빠름
-    const krNow = new Date(utcNow + KR_TIME_DIFF);
+    // 한국 표준시 현재 날짜
+    const today = dateHandlers.getCurrentKSTDate();
 
     const moreReportList = await reportDB.getReportListByReportedUser(client, reportedUser.id);
     let moreReportIdList = [];
@@ -198,13 +195,13 @@ module.exports = async (req, res) => {
       moreReportIdList.push(report.id);
     });
     if (moreReportList.length !== 0) {
-      moreReportResponseMessage = `[추가 신고 접수 권고] (${krNow.toLocaleString()} 기준) id ${
+      moreReportResponseMessage = `[추가 신고 접수 권고] (${today.toLocaleString()} 기준) id ${
         reportedUser.id
       }번 유저의 다른 글 또는 댓글에 대한 신고 중 아직 접수되지 않은 신고가 ${
         moreReportList.length
       }건 존재합니다. 기간이 지나고 신고를 접수할 경우 유저가 중복 제재를 받을 수 있으니 주의하시기 바랍니다. 관련 report id :  ${moreReportIdList}`;
     } else {
-      moreReportResponseMessage = `(${krNow.toLocaleString()} 기준) id ${
+      moreReportResponseMessage = `(${today.toLocaleString()} 기준) id ${
         reportedUser.id
       }번 유저에 대한 신고는 모두 접수 완료되었습니다.`;
     }

--- a/functions/api/routes/report/reportPUT.js
+++ b/functions/api/routes/report/reportPUT.js
@@ -195,13 +195,15 @@ module.exports = async (req, res) => {
       moreReportIdList.push(report.id);
     });
     if (moreReportList.length !== 0) {
-      moreReportResponseMessage = `[추가 신고 접수 권고] (${today.toLocaleString()} 기준) id ${
+      moreReportResponseMessage = `[추가 신고 접수 권고] (${today.format(
+        "YYYY.MM.DD HH:mm:ss",
+      )} 기준) id ${
         reportedUser.id
       }번 유저의 다른 글 또는 댓글에 대한 신고 중 아직 접수되지 않은 신고가 ${
         moreReportList.length
       }건 존재합니다. 기간이 지나고 신고를 접수할 경우 유저가 중복 제재를 받을 수 있으니 주의하시기 바랍니다. 관련 report id :  ${moreReportIdList}`;
     } else {
-      moreReportResponseMessage = `(${today.toLocaleString()} 기준) id ${
+      moreReportResponseMessage = `(${today.format("YYYY.MM.DD HH:mm:ss")} 기준) id ${
         reportedUser.id
       }번 유저에 대한 신고는 모두 접수 완료되었습니다.`;
     }

--- a/functions/api/routes/reviewPost/reviewPostDetailGET.js
+++ b/functions/api/routes/reviewPost/reviewPostDetailGET.js
@@ -34,7 +34,7 @@ module.exports = async (req, res) => {
     } else if (req.user.reportCount === 3) {
       reportPeriod = reportPeriodType.THIRD_PERIOD;
     } else if (req.user.reportCount >= 4) {
-      reportResponseMessage = `신고 누적이용자로 앞으로 글 열람 및 글 작성이 불가능합니다.`;
+      reportResponseMessage = `신고 누적으로 글 열람 및 작성이 영구적으로 제한됩니다.`;
     }
 
     // 신고 만료 날짜
@@ -44,8 +44,8 @@ module.exports = async (req, res) => {
     );
 
     reportResponseMessage = `신고 누적이용자로 ${expirationDate.format(
-      "YY년 MM월 DD일",
-    )}까지 글 열람 및 글 작성이 불가능합니다.`;
+      "YYYY년 MM월 DD일",
+    )}까지 글 열람 및 작성이 불가능합니다.`;
 
     return res
       .status(statusCode.FORBIDDEN)

--- a/functions/api/routes/reviewPost/reviewPostDetailGET.js
+++ b/functions/api/routes/reviewPost/reviewPostDetailGET.js
@@ -6,6 +6,8 @@ const db = require("../../../db/db");
 const { userDB, reviewPostDB, imageDB, majorDB, likeDB } = require("../../../db");
 const reviewPostContent = require("../../../constants/reviewPostContent");
 const slackAPI = require("../../../middlewares/slackAPI");
+const dateHandlers = require("../../../lib/dateHandlers");
+const reportPeriodType = require("../../../constants/reportPeriodType");
 
 module.exports = async (req, res) => {
   const { postId } = req.params;
@@ -17,17 +19,43 @@ module.exports = async (req, res) => {
       .send(util.fail(statusCode.BAD_REQUEST, responseMessage.NULL_VALUE));
   }
 
+  // 신고당한 유저
+  if (req.user.reportCreatedAt) {
+    // 유저 신고 기간
+    let reportPeriod;
+
+    // 알럿 메세지
+    let reportResponseMessage;
+
+    if (req.user.reportCount === 1) {
+      reportPeriod = reportPeriodType.FIRST_PERIOD;
+    } else if (req.user.reportCount === 2) {
+      reportPeriod = reportPeriodType.SECOND_PERIOD;
+    } else if (req.user.reportCount === 3) {
+      reportPeriod = reportPeriodType.THIRD_PERIOD;
+    } else if (req.user.reportCount >= 4) {
+      reportResponseMessage = `신고 누적이용자로 앞으로 글 열람 및 글 작성이 불가능합니다.`;
+    }
+
+    // 신고 만료 날짜
+    const expirationDate = dateHandlers.getExpirationDateByMonth(
+      req.user.reportCreatedAt,
+      reportPeriod,
+    );
+
+    reportResponseMessage = `신고 누적이용자로 ${expirationDate.format(
+      "YY년 MM월 DD일",
+    )}까지 글 열람 및 글 작성이 불가능합니다.`;
+
+    return res
+      .status(statusCode.FORBIDDEN)
+      .send(util.fail(statusCode.FORBIDDEN, reportResponseMessage));
+  }
   // 후기글 미등록 유저
   if (req.user.isReviewed === false) {
     return res
       .status(statusCode.FORBIDDEN)
       .send(util.fail(statusCode.FORBIDDEN, responseMessage.IS_REVIEWED_FALSE));
-  }
-  // 신고당한 유저
-  if (req.user.reportCreatedAt) {
-    return res
-      .status(statusCode.FORBIDDEN)
-      .send(util.fail(statusCode.FORBIDDEN, responseMessage.FORBIDDEN_ACCESS_REPORT));
   }
 
   let client;

--- a/functions/api/routes/reviewPost/reviewPostPOST.js
+++ b/functions/api/routes/reviewPost/reviewPostPOST.js
@@ -21,6 +21,8 @@ const {
   TIP,
 } = require("../../../constants/reviewPostContent");
 const slackAPI = require("../../../middlewares/slackAPI");
+const dateHandlers = require("../../../lib/dateHandlers");
+const reportPeriodType = require("../../../constants/reportPeriodType");
 
 module.exports = async (req, res) => {
   const {
@@ -44,9 +46,35 @@ module.exports = async (req, res) => {
 
   // 신고당한 유저
   if (req.user.reportCreatedAt) {
+    // 유저 신고 기간
+    let reportPeriod;
+
+    // 알럿 메세지
+    let reportResponseMessage;
+
+    if (req.user.reportCount === 1) {
+      reportPeriod = reportPeriodType.FIRST_PERIOD;
+    } else if (req.user.reportCount === 2) {
+      reportPeriod = reportPeriodType.SECOND_PERIOD;
+    } else if (req.user.reportCount === 3) {
+      reportPeriod = reportPeriodType.THIRD_PERIOD;
+    } else if (req.user.reportCount >= 4) {
+      reportResponseMessage = `신고 누적이용자로 앞으로 글 열람 및 글 작성이 불가능합니다.`;
+    }
+
+    // 신고 만료 날짜
+    const expirationDate = dateHandlers.getExpirationDateByMonth(
+      req.user.reportCreatedAt,
+      reportPeriod,
+    );
+
+    reportResponseMessage = `신고 누적이용자로 ${expirationDate.format(
+      "YY년 MM월 DD일",
+    )}까지 글 열람 및 글 작성이 불가능합니다.`;
+
     return res
       .status(statusCode.FORBIDDEN)
-      .send(util.fail(statusCode.FORBIDDEN, responseMessage.FORBIDDEN_ACCESS_REPORT));
+      .send(util.fail(statusCode.FORBIDDEN, reportResponseMessage));
   }
 
   let client;

--- a/functions/api/routes/reviewPost/reviewPostPOST.js
+++ b/functions/api/routes/reviewPost/reviewPostPOST.js
@@ -59,7 +59,7 @@ module.exports = async (req, res) => {
     } else if (req.user.reportCount === 3) {
       reportPeriod = reportPeriodType.THIRD_PERIOD;
     } else if (req.user.reportCount >= 4) {
-      reportResponseMessage = `신고 누적이용자로 앞으로 글 열람 및 글 작성이 불가능합니다.`;
+      reportResponseMessage = `신고 누적으로 글 열람 및 작성이 영구적으로 제한됩니다.`;
     }
 
     // 신고 만료 날짜
@@ -69,8 +69,8 @@ module.exports = async (req, res) => {
     );
 
     reportResponseMessage = `신고 누적이용자로 ${expirationDate.format(
-      "YY년 MM월 DD일",
-    )}까지 글 열람 및 글 작성이 불가능합니다.`;
+      "YYYY년 MM월 DD일",
+    )}까지 글 열람 및 작성이 불가능합니다.`;
 
     return res
       .status(statusCode.FORBIDDEN)

--- a/functions/lib/dateHandlers.js
+++ b/functions/lib/dateHandlers.js
@@ -1,0 +1,30 @@
+// 현재 날짜를 미국 표준시로 반환
+// return type: number
+const getCurrentUTCNumberDate = () => {
+  const today = new Date();
+  const UTCNow = today.getTime() + today.getTimezoneOffset() * 60 * 1000;
+  return UTCNow;
+};
+
+// 현재 날짜를 미국 표준시로 반환
+// return type: object (Date)
+const getCurrentUTCDate = () => {
+  const UTCNow = new Date(getCurrentUTCNumberDate());
+  return UTCNow;
+};
+
+// 현재 날짜를 한국 표준시로 반환
+// return type: object (Date)
+const getCurrentKSTDate = () => {
+  const UTCNow = getCurrentUTCNumberDate();
+
+  const KST_TIME_DIFF = 9 * 60 * 60 * 1000; // UTC보다 9시간 빠름
+  const KSTNow = new Date(UTCNow + KST_TIME_DIFF);
+  return KSTNow;
+};
+
+module.exports = {
+  getCurrentUTCNumberDate,
+  getCurrentUTCDate,
+  getCurrentKSTDate,
+};

--- a/functions/lib/dateHandlers.js
+++ b/functions/lib/dateHandlers.js
@@ -1,25 +1,20 @@
-// 현재 날짜를 미국 표준시로 반환
-// return type: number
-const getCurrentUTCNumberDate = () => {
-  const today = new Date();
-  const UTCNow = today.getTime() + today.getTimezoneOffset() * 60 * 1000;
-  return UTCNow;
-};
+const dayjs = require("dayjs");
+const timezone = require("dayjs/plugin/timezone");
+const utc = require("dayjs/plugin/utc");
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 // 현재 날짜를 미국 표준시로 반환
 // return type: object(Date)
 const getCurrentUTCDate = () => {
-  const UTCNow = new Date(getCurrentUTCNumberDate());
+  const UTCNow = dayjs().utc();
   return UTCNow;
 };
 
 // 현재 날짜를 한국 표준시로 반환
 // return type: object(Date)
 const getCurrentKSTDate = () => {
-  const UTCNow = getCurrentUTCNumberDate();
-
-  const KST_TIME_DIFF = 9 * 60 * 60 * 1000; // UTC보다 9시간 빠름
-  const KSTNow = new Date(UTCNow + KST_TIME_DIFF);
+  const KSTNow = dayjs().tz("Asia/Seoul");
   return KSTNow;
 };
 
@@ -27,13 +22,15 @@ const getCurrentKSTDate = () => {
 // input type: baseDate - object(Date), expirationMonth(number)
 // return type: object(Date)
 const getExpirationDateByMonth = (baseDate, expirationMonth) => {
-  // setMonth parameter는 1 월에서 12 월까지의 월을 나타내는 0에서 11 사이의 정수
-  const expirationDate = new Date(baseDate.setMonth(baseDate.getMonth() + expirationMonth));
+  // set은 1 월에서 12 월까지의 월을 나타내는 0에서 11 사이의 정수를 받음
+  const expirationDate = dayjs(baseDate).set(
+    "month",
+    dayjs(baseDate).get("month") + expirationMonth,
+  );
   return expirationDate;
 };
 
 module.exports = {
-  getCurrentUTCNumberDate,
   getCurrentUTCDate,
   getCurrentKSTDate,
   getExpirationDateByMonth,

--- a/functions/lib/dateHandlers.js
+++ b/functions/lib/dateHandlers.js
@@ -7,14 +7,14 @@ const getCurrentUTCNumberDate = () => {
 };
 
 // 현재 날짜를 미국 표준시로 반환
-// return type: object (Date)
+// return type: object(Date)
 const getCurrentUTCDate = () => {
   const UTCNow = new Date(getCurrentUTCNumberDate());
   return UTCNow;
 };
 
 // 현재 날짜를 한국 표준시로 반환
-// return type: object (Date)
+// return type: object(Date)
 const getCurrentKSTDate = () => {
   const UTCNow = getCurrentUTCNumberDate();
 
@@ -23,8 +23,18 @@ const getCurrentKSTDate = () => {
   return KSTNow;
 };
 
+// month만큼 지난 후 만료되는 날짜를 반환
+// input type: baseDate - object(Date), expirationMonth(number)
+// return type: object(Date)
+const getExpirationDateByMonth = (baseDate, expirationMonth) => {
+  // setMonth parameter는 1 월에서 12 월까지의 월을 나타내는 0에서 11 사이의 정수
+  const expirationDate = new Date(baseDate.setMonth(baseDate.getMonth() + expirationMonth));
+  return expirationDate;
+};
+
 module.exports = {
   getCurrentUTCNumberDate,
   getCurrentUTCDate,
   getCurrentKSTDate,
+  getExpirationDateByMonth,
 };


### PR DESCRIPTION
- closed #240 
- [x] `리펙토링` dateHandlers 생성: 미국 표준시간대(UTC) 및 한국 표준시간대(KST) 기준으로 현재 시간 구하는 함수, month 지난 후 만료기간이 언제인지 구하는 함수
ex) 닉네임 변경 제한 같은 경우에도 닉네임 변경 시간, 개월수만 넣으면 언제까지 닉네임 변경이 불가한지 날짜 구하는 데 사용할 수 있음
- [x] `리펙토링` dayjs 모듈 사용 - 8차 세미나에서 언급되었음
- [x] `변경사항` 알럿 메세지 지점 변경됨 -> 로그인 후 report period 반환하는 내용은 delete, 불가항목 클릭 시 알럿창에 뜨는 메세지 가공하여 response message로 전달 (fail이기 때문에 data 전송이 불가해 직접 쓸 수 있도록 response message에 그대로 전달) 
- [x] 신고 PUT 기능 및 로그인 시 신고 만료 기능, 불가항목 클릭 시 알럿 기능 모두 postman 테스트 완료

---
<img width="1008" alt="스크린샷 2022-02-20 오전 12 53 05" src="https://user-images.githubusercontent.com/76513385/154808634-9b7eb011-ef52-492c-aacc-3ecd95598c78.png">

