### PR TITLE
[REFACTOR] DB 접근 속도 개선

### DIFF
--- a/functions/api/routes/notification/notificationReadPUT.js
+++ b/functions/api/routes/notification/notificationReadPUT.js
@@ -53,19 +53,18 @@ module.exports = async (req, res) => {
         .send(util.fail(statusCode.NOT_FOUND, responseMessage.NO_NOTIFICATION));
     }
 
-    updatedNotifications = await Promise.all(
-      updatedNotifications.map(async (notification) => {
-        return {
-          notificationId: notification.id,
-          notificationPostId: notification.postId,
-          receiverId: notification.receiverId,
-          isRead: notification.isRead,
-          createdAt: notification.createdAt,
-          updatedAt: notification.updatedAt,
-          isDeleted: notification.isDeleted,
-        };
-      }),
-    );
+    updatedNotifications = updatedNotifications.map((notification) => {
+      return {
+        notificationId: notification.id,
+        notificationPostId: notification.postId,
+        receiverId: notification.receiverId,
+        isRead: notification.isRead,
+        createdAt: notification.createdAt,
+        updatedAt: notification.updatedAt,
+        isDeleted: notification.isDeleted,
+      };
+    });
+
     res
       .status(statusCode.OK)
       .send(

--- a/functions/db/user.js
+++ b/functions/db/user.js
@@ -111,9 +111,18 @@ const getUserByUserId = async (client, userId) => {
 const getUserByFirebaseId = async (client, firebaseId) => {
   const { rows } = await client.query(
     `
-    SELECT * FROM "user" u
-    WHERE firebase_id = $1
-      AND is_deleted = false
+    SELECT u.*, m1.major_name first_major_name, m2.major_name second_major_name
+    FROM "user" u
+    INNER JOIN major m1
+      ON u.first_major_id = m1.id
+      AND u.is_deleted = false
+      AND m1.is_deleted = false
+    INNER JOIN major m2
+      ON u.second_major_id = m2.id
+      AND u.is_deleted = false
+      AND m2.is_deleted = false
+    WHERE u.firebase_id = $1
+    AND u.is_deleted = false
     `,
     [firebaseId],
   );

--- a/functions/db/user.js
+++ b/functions/db/user.js
@@ -90,9 +90,18 @@ const updateUserByIsReviewed = async (client, isReviewed, userId) => {
 const getUserByUserId = async (client, userId) => {
   const { rows } = await client.query(
     `
-      SELECT * FROM "user"
-      WHERE id = $1
-      AND is_deleted = false
+      SELECT u.*, m1.major_name first_major_name, m2.major_name second_major_name
+      FROM "user" u
+      INNER JOIN major m1
+        ON u.first_major_id = m1.id
+        AND u.is_deleted = false
+        AND m1.is_deleted = false
+      INNER JOIN major m2
+        ON u.second_major_id = m2.id
+        AND u.is_deleted = false
+        AND m2.is_deleted = false
+      WHERE u.id = $1
+      AND u.is_deleted = false
       `,
     [userId],
   );


### PR DESCRIPTION
- closed #264 

- [x] `알림 읽기` 필요 없는 비동기 처리 삭제
- [x] `유저 탈퇴` 쿼리 오타 수정 commet -> comment
- [x] `majorName 필요한 다수 api` majorName 구하는 쿼리 삭제하고 개별 쿼리에서 majorDB JOIN하여 구함. (reviewPost, classroomPost, user)
- [x] `질문글, 정보글 상세보기` 댓글 리스트 map에서 DB 접근 안 하도록 변경, 삭제된 댓글도 보이게 버그 수정도 함께 함
(댓글 많은 질문글 기준으로 속도 1/10로 개선됨 1000~2000ms -> 100ms 미만)