### PR TITLE
no slack alerts in local env, add env to message

### DIFF
--- a/functions/middlewares/slackAPI.js
+++ b/functions/middlewares/slackAPI.js
@@ -12,17 +12,21 @@ const DEV_WEB_HOOK_DUMMY_MONITORING = process.env.DEV_WEB_HOOK_DUMMY_MONITORING;
 
 const sendMessageToSlack = (message, apiEndPoint) => {
   // send message to slack using slack webhook
-  try {
-    axios
-      .post(apiEndPoint, { text: message })
-      .then((response) => {})
-      .catch((e) => {
-        throw e;
-      });
-  } catch (e) {
-    console.error(e);
-    // when slack webhook error occurs, logging error
-    functions.logger.error("[slackAPI 에러]", { error: e });
+  if (process.env.NODE_ENV !== "local") {
+    try {
+      axios
+        .post(apiEndPoint, {
+          text: `🚨 *${process.env.NODE_ENV}*`.toUpperCase() + "\n" + message,
+        })
+        .then((response) => {})
+        .catch((e) => {
+          throw e;
+        });
+    } catch (e) {
+      console.error(e);
+      // when slack webhook error occurs, logging error
+      functions.logger.error("[slackAPI 에러]", { error: e });
+    }
   }
 };
 


### PR DESCRIPTION
- closes #302 

- 로컬 실행은 슬랙 알림이 안 오도록 했습니다.
`.env.dev에서 NODE_ENV 변수 지워주세요`
- message에 환경 확인할 수 있도록 추가했습니다.