### PR TITLE
sort major list

### DIFF
--- a/functions/api/routes/major/majorListGET.js
+++ b/functions/api/routes/major/majorListGET.js
@@ -4,11 +4,11 @@ const responseMessage = require("../../../constants/responseMessage");
 const db = require("../../../db/db");
 const { majorDB } = require("../../../db");
 const errorHandlers = require("../../../lib/errorHandlers");
-const { NO_INFO, NOT_ENTERED } = require("../../../constants/major");
+const { NO_INFO, NOT_ENTERED, NO_MAJOR } = require("../../../constants/major");
 
 module.exports = async (req, res) => {
   const { universityId } = req.params;
-  const { filter } = req.query;
+  const { filter, exclude } = req.query;
 
   if (!universityId || !filter) {
     return res
@@ -26,15 +26,20 @@ module.exports = async (req, res) => {
     if (filter === "all") {
       isFirstMajor = [true, false];
       isSecondMajor = [true, false];
-      invisibleMajorIds = NO_INFO.concat(NOT_ENTERED);
+
+      if (exclude === "noMajor") {
+        invisibleMajorIds = [...NO_INFO, ...NOT_ENTERED, ...NO_MAJOR];
+      } else {
+        invisibleMajorIds = [...NO_INFO, ...NOT_ENTERED];
+      }
     } else if (filter === "firstMajor") {
       isFirstMajor = [true];
       isSecondMajor = [true, false];
-      invisibleMajorIds = NO_INFO;
+      invisibleMajorIds = [...NO_INFO, ...NO_MAJOR];
     } else if (filter === "secondMajor") {
       isFirstMajor = [true, false];
       isSecondMajor = [true];
-      invisibleMajorIds = NO_INFO;
+      invisibleMajorIds = [...NO_INFO, ...NO_MAJOR];
     } else {
       return res
         .status(statusCode.BAD_REQUEST)

--- a/functions/api/routes/major/majorListGET.js
+++ b/functions/api/routes/major/majorListGET.js
@@ -23,25 +23,25 @@ module.exports = async (req, res) => {
     client = await db.connect(req);
 
     // filter & exclude query
-    let isFirstMajor, isSecondMajor, invisibleMajorIds;
+    let isFirstMajor, isSecondMajor, invisibleMajorNames;
 
     if (filter === "all") {
       isFirstMajor = [true, false];
       isSecondMajor = [true, false];
 
       if (exclude === "noMajor") {
-        invisibleMajorIds = [...NO_INFO, ...NOT_ENTERED, ...NO_MAJOR];
+        invisibleMajorNames = [...NO_INFO, ...NOT_ENTERED, ...NO_MAJOR];
       } else {
-        invisibleMajorIds = [...NO_INFO, ...NOT_ENTERED];
+        invisibleMajorNames = [...NO_INFO, ...NOT_ENTERED];
       }
     } else if (filter === "firstMajor") {
       isFirstMajor = [true];
       isSecondMajor = [true, false];
-      invisibleMajorIds = [...NO_INFO, ...NO_MAJOR];
+      invisibleMajorNames = [...NO_INFO, ...NO_MAJOR];
     } else if (filter === "secondMajor") {
       isFirstMajor = [true, false];
       isSecondMajor = [true];
-      invisibleMajorIds = [...NO_INFO, ...NO_MAJOR];
+      invisibleMajorNames = [...NO_INFO, ...NO_MAJOR];
     } else {
       return res
         .status(statusCode.BAD_REQUEST)
@@ -53,7 +53,7 @@ module.exports = async (req, res) => {
       universityId,
       isFirstMajor,
       isSecondMajor,
-      invisibleMajorIds,
+      invisibleMajorNames,
     );
 
     // separate major by default major, other major, other campus
@@ -62,7 +62,7 @@ module.exports = async (req, res) => {
       otherCampus = [];
 
     majorList.map((m) => {
-      if ([...NOT_ENTERED, ...NO_MAJOR].includes(m.majorId)) {
+      if ([...NOT_ENTERED, ...NO_MAJOR].includes(m.majorName)) {
         otherMajor.push(m);
       } else if (m.majorName.includes("(")) {
         otherCampus.push(m);

--- a/functions/api/routes/major/majorListGET.js
+++ b/functions/api/routes/major/majorListGET.js
@@ -57,7 +57,6 @@ module.exports = async (req, res) => {
     );
 
     // separate major by default major, other major, other campus
-
     let defaultMajor = [],
       otherMajor = [],
       otherCampus = [];

--- a/functions/api/routes/major/majorListGET.js
+++ b/functions/api/routes/major/majorListGET.js
@@ -4,6 +4,7 @@ const responseMessage = require("../../../constants/responseMessage");
 const db = require("../../../db/db");
 const { majorDB } = require("../../../db");
 const errorHandlers = require("../../../lib/errorHandlers");
+const { NO_INFO, NOT_ENTERED } = require("../../../constants/major");
 
 module.exports = async (req, res) => {
   const { universityId } = req.params;
@@ -20,35 +21,33 @@ module.exports = async (req, res) => {
   try {
     client = await db.connect(req);
 
-    let majorList;
+    let isFirstMajor, isSecondMajor, invisibleMajorIds;
 
     if (filter === "all") {
-      majorList = await majorDB.getMajorListByUniversityId(
-        client,
-        universityId,
-        [true, false],
-        [true, false],
-      );
-      majorList.shift();
+      isFirstMajor = [true, false];
+      isSecondMajor = [true, false];
+      invisibleMajorIds = NO_INFO.concat(NOT_ENTERED);
     } else if (filter === "firstMajor") {
-      majorList = await majorDB.getMajorListByUniversityId(
-        client,
-        universityId,
-        [true],
-        [true, false],
-      );
+      isFirstMajor = [true];
+      isSecondMajor = [true, false];
+      invisibleMajorIds = NO_INFO;
     } else if (filter === "secondMajor") {
-      majorList = await majorDB.getMajorListByUniversityId(
-        client,
-        universityId,
-        [true, false],
-        [true],
-      );
+      isFirstMajor = [true, false];
+      isSecondMajor = [true];
+      invisibleMajorIds = NO_INFO;
     } else {
       return res
         .status(statusCode.BAD_REQUEST)
         .send(util.fail(statusCode.BAD_REQUEST, responseMessage.INCORRECT_FILTER));
     }
+
+    const majorList = await majorDB.getMajorListByUniversityId(
+      client,
+      universityId,
+      isFirstMajor,
+      isSecondMajor,
+      invisibleMajorIds,
+    );
 
     res
       .status(statusCode.OK)

--- a/functions/constants/major.js
+++ b/functions/constants/major.js
@@ -1,9 +1,9 @@
 const NOT_ENTERED = [1];
 const NO_INFO = [127];
-const ALL = [128];
+const NO_MAJOR = [128];
 
 module.exports = {
   NOT_ENTERED,
   NO_INFO,
-  ALL,
+  NO_MAJOR,
 };

--- a/functions/constants/major.js
+++ b/functions/constants/major.js
@@ -1,0 +1,9 @@
+const NOT_ENTERED = [1];
+const NO_INFO = [127];
+const ALL = [128];
+
+module.exports = {
+  NOT_ENTERED,
+  NO_INFO,
+  ALL,
+};

--- a/functions/constants/major.js
+++ b/functions/constants/major.js
@@ -1,6 +1,6 @@
-const NOT_ENTERED = [1];
-const NO_INFO = [127];
-const NO_MAJOR = [128];
+const NOT_ENTERED = ["미진입"];
+const NO_INFO = ["정보없음"];
+const NO_MAJOR = ["학과무관", "학과 무관"];
 
 module.exports = {
   NOT_ENTERED,

--- a/functions/db/major.js
+++ b/functions/db/major.js
@@ -5,7 +5,7 @@ const getMajorListByUniversityId = async (
   universityId,
   isFirstMajor,
   isSecondMajor,
-  invisibleMajorIds,
+  invisibleMajorNames,
 ) => {
   const { rows } = await client.query(
     `
@@ -13,10 +13,10 @@ const getMajorListByUniversityId = async (
     WHERE m.university_id = $1
     AND m.is_first_major IN (${isFirstMajor.join()})
     AND m.is_second_major IN (${isSecondMajor.join()})
-    AND m.id NOT IN (${invisibleMajorIds.join()})
+    AND m.major_name <> all ($2)
     AND is_deleted = false
     `,
-    [universityId],
+    [universityId, invisibleMajorNames],
   );
   return convertSnakeToCamel.keysToCamel(rows);
 };

--- a/functions/db/major.js
+++ b/functions/db/major.js
@@ -9,13 +9,12 @@ const getMajorListByUniversityId = async (
 ) => {
   const { rows } = await client.query(
     `
-    SELECT id as major_id, major_name, is_first_major, is_second_major FROM "major" m
+    SELECT id as major_id, major_name FROM "major" m
     WHERE m.university_id = $1
     AND m.is_first_major IN (${isFirstMajor.join()})
     AND m.is_second_major IN (${isSecondMajor.join()})
     AND m.id NOT IN (${invisibleMajorIds.join()})
     AND is_deleted = false
-    ORDER BY major_id
     `,
     [universityId],
   );

--- a/functions/db/major.js
+++ b/functions/db/major.js
@@ -1,13 +1,19 @@
 const convertSnakeToCamel = require("../lib/convertSnakeToCamel");
 
-const getMajorListByUniversityId = async (client, universityId, isFirstMajor, isSecondMajor) => {
+const getMajorListByUniversityId = async (
+  client,
+  universityId,
+  isFirstMajor,
+  isSecondMajor,
+  invisibleMajorIds,
+) => {
   const { rows } = await client.query(
     `
     SELECT id as major_id, major_name, is_first_major, is_second_major FROM "major" m
     WHERE m.university_id = $1
     AND m.is_first_major IN (${isFirstMajor.join()})
     AND m.is_second_major IN (${isSecondMajor.join()})
-    AND m.major_name != '정보없음'
+    AND m.id NOT IN (${invisibleMajorIds.join()})
     AND is_deleted = false
     ORDER BY major_id
     `,


### PR DESCRIPTION
- closes #300 

- 학과 무관 university 1 추가 id 128 (isFirstMajor false, isSecondMajor false)
- 다른 university도 학과 무관, 미진입 id 붙여서 사용하기로 함

---
- 해야하는 정렬 총 4가지 기본적으로 정보없음은 가져오지 않음.
  - filter all이면서 미진입 x, 학과 무관 o
  - filter all이면서 미진입 x, 학과 무관 x
  - filter firstMajor이면서 미진입x, 학과 무관x
  - filter secondMajor이면서 미진입o, 학과 무관x

- filter query는 기존과 동일
- exclude query는 filter = all 이면서 exclude = noMajor만 가능. 그 외 워딩 및 조건일 때 별도 처리는 하지 않음. (필터링 안되고 아무 효과 없음)
  - exclude query 없이도 filter = all은 미진입을 포함시키지 않고, filter = firstMajor, secondMajor는 학과 무관을 포함시키지 않음