### PR TITLE
[FIX] fix env to uppercase

### DIFF
--- a/functions/api/routes/app/versionRecentGET.js
+++ b/functions/api/routes/app/versionRecentGET.js
@@ -10,7 +10,7 @@ module.exports = async (req, res) => {
     res.status(statusCode.OK).send(
       util.success(statusCode.OK, responseMessage.READ_APP_VERSION, {
         AOS: process.env.VERSION_AOS,
-        iOS: process.env.VERSION_iOS,
+        iOS: process.env.VERSION_IOS,
       }),
     );
   } catch (error) {


### PR DESCRIPTION
- closes #357 
- npm run serve 할 때 로컬 환경에서는 따로 검증하지 않지만, 배포할 때는 .env 변수가 uppercase가 아닐 때 에러가 발생합니다.
참고하여 기존 .env `VERSION_iOS -> VERSION_IOS`로 대문자 통일해주시기 바랍니다