### PR TITLE
[HOTFIX] fix nickname duplication error

### DIFF
--- a/functions/db/user.js
+++ b/functions/db/user.js
@@ -6,7 +6,6 @@ const getUserByNickname = async (client, nickname) => {
     `
       SELECT id, nickname FROM "user"
       WHERE nickname = $1
-      AND is_deleted = false
       `,
     [nickname],
   );


### PR DESCRIPTION
* postgreSQL에서 nickname duplicate error로 인해 이미 디비에 존재하는 같은 닉네임으로 가입 / 변경 오류를 고쳤습니다.
* 이미 prod 배포 완료하였습니다.